### PR TITLE
Net::MAC::Vendor: Fix subtle ARGV manipulation bug

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,6 +1,7 @@
 Revision history for Perl module Net::MAC::Vendor
 
 {{$NEXT}}
+        * Fix issue where load_cache causes problems with <> after.
 
 1.265     2019-04-12 23:55:27Z
         * properly remove Compress::* from list of mandatory prereqs

--- a/lib/Net/MAC/Vendor.pm
+++ b/lib/Net/MAC/Vendor.pm
@@ -473,7 +473,7 @@ sub load_cache {
 				return;
 				}
 
-			do { local( @ARGV, $/ ) = $source; <> }
+			do { local( *ARGV, $/ ); @ARGV = $source; <> }
 			}
 		else {
 			#say time . " Fetching URL";


### PR DESCRIPTION
* load_cache: Fix a hard to track down problem where when `@ARGV` is
  localized, but `$ARGV` is *not*, use of `<>` after calling `load_cache`
  is bugged:
```
$ printf '%s\n' foo bar | perl -MData::Dumper -MNet::MAC::Vendor -we '
Net::MAC::Vendor::load_cache("/dev/null") if (0);
foreach my $idx (0..1) {
	while (<>) { chomp; print STDERR Dumper "$idx $_" }
}'
$VAR1 = '0 foo';
$VAR1 = '0 bar';
```
vs
```
$ printf '%s\n' foo bar | perl -MData::Dumper -MNet::MAC::Vendor -we '
Net::MAC::Vendor::load_cache("/dev/null") if (1);
foreach my $idx (0..1) {
	while (<>) { chomp; print STDERR Dumper "$idx $_" }
}'
$VAR1 = '1 foo';
$VAR1 = '1 bar';
```
  The problem explained: http://blogs.perl.org/users/book/2018/07/a-widespread-and-broken-perl-idiom.html
  Modeled after this fix: https://github.com/book/App-Wallflower/commit/0aff3729f9e470fd25ec9a1375eaf1a76abc658d